### PR TITLE
Fix JSON handling in resume analysis

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -13,9 +13,13 @@ def health_check():
 
 @main_routes.route('/analyze-resume', methods=['POST'])
 def analyze():
-    data = request.json
+    """Analyze the provided resume text."""
+    # Safely parse JSON, falling back to an empty dict if parsing fails
+    data = request.get_json(silent=True) or {}
     resume_text = data.get("resume", "")
+
     if not resume_text:
         return {"error": "No resume text provided"}, 400
+
     result = analyze_resume(resume_text)
     return result

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -27,3 +27,8 @@ def test_analyze_resume_empty(client):
     response = client.post("/analyze-resume", json={})
     assert response.status_code == 400
     assert response.json == {"error": "No resume text provided"}
+
+def test_analyze_resume_no_json(client):
+    response = client.post("/analyze-resume")
+    assert response.status_code == 400
+    assert response.json == {"error": "No resume text provided"}


### PR DESCRIPTION
## Summary
- fix `/analyze-resume` to handle missing JSON gracefully
- add regression test for requests with no JSON body

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fec3fec5c8327bff46d267d4f032a